### PR TITLE
Add TodoList form submission test

### DIFF
--- a/__tests__/TodoList.test.js
+++ b/__tests__/TodoList.test.js
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TodoList from '../TodoList';
+
+// Ensure new todo item appears in list when form is submitted
+
+test('adds a new todo item when the form is submitted', async () => {
+  render(<TodoList />);
+
+  const input = screen.getByPlaceholderText(/add a todo/i);
+  const button = screen.getByRole('button', { name: /add todo/i });
+
+  await userEvent.type(input, 'learn testing');
+  await userEvent.click(button);
+
+  expect(screen.getByText('learn testing')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add test folder and TodoList test verifying new todo item renders on form submission

## Testing
- `yarn test --watchAll=false` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68683c7612b08329aa2373515fa71157